### PR TITLE
Update package.json to allow the build to run due to incompatible dependacies with NPM version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "electron-context-menu": "^2.5.0",
     "electron-localshortcut": "^3.2.1",
     "electron-store": "^7.0.2",
-    "electron-updater": "^4.3.8",
+    "electron-updater": "4.3.8",
     "emoji-datasource": "^6.0.1",
     "emoji-mart-vue-fast": "^9.1.2",
     "emoji-regex": "^9.2.2",


### PR DESCRIPTION
Fixes building and fs::promises for Npm 14. Otherwise the ^ installs a newer build for electron which breaks the run process as the NPM versions will mismatch.

Refer to my concern here: https://github.com/sgtaziz/WebMessage/issues/194#issuecomment-1450902516